### PR TITLE
Feature uart fixes

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1262,6 +1262,8 @@ static int uarte_instance_init(struct device *dev,
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 
+	nrf_uarte_disable(uarte);
+
 	nrf_gpio_pin_write(config->pseltxd, 1);
 	nrf_gpio_cfg_output(config->pseltxd);
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -15,6 +15,7 @@
 #include <sys/util.h>
 #include <kernel.h>
 #include <logging/log.h>
+#include <logging/log_ctrl.h>
 LOG_MODULE_REGISTER(uart_nrfx_uarte, LOG_LEVEL_ERR);
 
 /* Generalize PPI or DPPI channel management */
@@ -1021,7 +1022,7 @@ static void uarte_nrfx_poll_out(struct device *dev, unsigned char c)
 		lock = &data->poll_out_lock;
 
 	if (!k_is_in_isr()) {
-		u8_t safety_cnt = 100;
+		u16_t safety_cnt = 10000;
 
 		while (atomic_cas((atomic_t *) lock,
 				(atomic_val_t) 0,
@@ -1031,6 +1032,7 @@ static void uarte_nrfx_poll_out(struct device *dev, unsigned char c)
 			 */
 			k_msleep(1);
 			if (--safety_cnt == 0) {
+				LOG_ERR("Timeout waiting for lock");
 				return;
 			}
 		}
@@ -1046,11 +1048,13 @@ static void uarte_nrfx_poll_out(struct device *dev, unsigned char c)
 	nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTTX);
 
 	/* Wait for transmitter to be ready */
-	int res;
+	int res = 0;
 
 	NRFX_WAIT_FOR(nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDTX),
-		      1000, 1, res);
-
+		      UINT_MAX, 1, res);
+	if (!res) {
+		LOG_ERR("Timeout waiting for ENDTX");
+	}
 	/* Deactivate the transmitter so that it does not needlessly
 	 * consume power.
 	 */
@@ -1059,6 +1063,7 @@ static void uarte_nrfx_poll_out(struct device *dev, unsigned char c)
 	/* Release the lock. */
 	*lock = 0;
 }
+
 #ifdef UARTE_INTERRUPT_DRIVEN
 /** Interrupt driven FIFO fill function */
 static int uarte_nrfx_fifo_fill(struct device *dev,

--- a/lib/os/work_q.c
+++ b/lib/os/work_q.c
@@ -25,6 +25,7 @@ void z_work_q_main(void *work_q_ptr, void *p2, void *p3)
 		}
 
 		handler = work->handler;
+		__ASSERT(handler != NULL, "handler must be provided");
 
 		/* Reset pending state so it can be resubmitted by handler */
 		if (atomic_test_and_clear_bit(work->flags,


### PR DESCRIPTION
For bringing up the Apricity gateway on NCS 1.3.0, make a few changes:
- official changes, already accepted and merged into Zephyr:
1. modify uart_nrfx_uarte.c init function to disable UART before reconfiguring pins
2. add assert to detect rare condition where out of order execution of work queue init function
and invocation of work item leads to calling a null function pointer
- unofficial fix to uart_nrfx_uarte.c: uarte_nrfx_poll_out() to prevent invisible timeouts
on hardware flow control (bug reported and under discussion)