### PR TITLE
Feature ncs 1.5.0 rc1

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -475,6 +475,7 @@ int __weak bt_hci_transport_setup(const struct device *dev)
 static int h4_open(void)
 {
 	int ret;
+	k_tid_t tid;
 
 	BT_DBG("");
 
@@ -488,11 +489,12 @@ static int h4_open(void)
 
 	uart_irq_callback_set(h4_dev, bt_uart_isr);
 
-	k_thread_create(&rx_thread_data, rx_thread_stack,
-			K_KERNEL_STACK_SIZEOF(rx_thread_stack),
-			rx_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_RX_PRIO),
-			0, K_NO_WAIT);
+	tid = k_thread_create(&rx_thread_data, rx_thread_stack,
+			      K_KERNEL_STACK_SIZEOF(rx_thread_stack),
+			      rx_thread, NULL, NULL, NULL,
+			      K_PRIO_COOP(CONFIG_BT_RX_PRIO),
+			      0, K_NO_WAIT);
+	k_thread_name_set(tid, "bt_rx_thread");
 
 	return 0;
 }

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -603,6 +603,7 @@ struct shell_flags {
 	uint32_t insert_mode :1; /*!< Controls insert mode for text introduction.*/
 	uint32_t use_colors  :1; /*!< Controls colored syntax.*/
 	uint32_t echo        :1; /*!< Controls shell echo.*/
+	uint32_t obscure     :1; /*!< If echo on, print asterisk instead */
 	uint32_t processing  :1; /*!< Shell is executing process function.*/
 	uint32_t tx_rdy      :1;
 	uint32_t mode_delete :1; /*!< Operation mode of backspace key */
@@ -989,6 +990,18 @@ int shell_execute_cmd(const struct shell *shell, const char *cmd);
  * @retval -EINVAL if invalid root command is provided.
  */
 int shell_set_root_cmd(const char *cmd);
+
+/** @brief Set unfiltered argument number.
+ *
+ *  If set to a value less than CONFIG_SHELL_ARGC_MAX, when reached by a
+ *  given shell command, all characters until the final `\0' are passed
+ *  to this argument number unmodified.
+ *
+ *  @param arg Argument number which gets all remaining characters on the line.
+ *
+ *  @returns previous value.
+ */
+uint8_t shell_set_unfiltered_argument(uint8_t arg);
 
 /**
  * @}

--- a/include/sys/sys_heap.h
+++ b/include/sys/sys_heap.h
@@ -61,6 +61,13 @@ struct z_heap_stress_result {
 	uint64_t accumulated_in_use_bytes;
 };
 
+struct sys_heap_stats {
+	uint32_t avail_chunks;
+	uint32_t avail_chunks_min;
+	uint32_t avail_contig;
+	uint32_t avail_contig_min;
+};
+
 /** @brief Initialize sys_heap
  *
  * Initializes a sys_heap struct to manage the specified memory.
@@ -202,5 +209,24 @@ void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
  * @param h Heap to print information about
  */
 void sys_heap_dump(struct sys_heap *h);
+
+/** @brief Print heap structure availability statistics to the console
+ *
+ * Prints a line detailing available heap memory and contiguous available heap
+ * memory, including historical minimums.
+ *
+ * @param h Heap to print information about
+ */
+void sys_heap_print_stats(struct sys_heap *h);
+
+/** @brief Write heap structure availability statistics to a struct
+ *
+ * Fills a struct detailing available heap memory and contiguous available heap
+ * memory, including historical minimums.
+ *
+ * @param h Heap to get information about
+ * @param stats struct to fill
+ */
+void sys_heap_get_stats(struct sys_heap *h, struct sys_heap_stats *stats);
 
 #endif /* ZEPHYR_INCLUDE_SYS_SYS_HEAP_H_ */

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -362,8 +362,13 @@ uint32_t heap_stats(bool print)
 	struct sys_heap *s_heap = &k_heap->heap;
 	struct z_heap *z_heap = s_heap->heap;
 
+	extern struct k_heap library_heap;
+	struct k_heap *lk_heap = &library_heap;
+	struct sys_heap *ls_heap = &lk_heap->heap;
+	struct z_heap *lz_heap = ls_heap->heap;
+
 	if (print) {
-		printk("Heap stats for %p | Free: %u (min %u) "
+		printk("Heap stats for _system_heap: %p | Free: %u (min %u) "
 		       "| Contiguous: %u (min %u) | Total: %u\n",
 		       z_heap,
 		       z_heap->avail_chunks * CHUNK_UNIT,
@@ -371,6 +376,14 @@ uint32_t heap_stats(bool print)
 		       z_heap->avail_contig * CHUNK_UNIT,
 		       z_heap->avail_contig_min * CHUNK_UNIT,
 		       z_heap->len * CHUNK_UNIT);
+		printk("Heap stats for library_heap: %p | Free: %u (min %u) "
+		       "| Contiguous: %u (min %u) | Total: %u\n",
+		       lz_heap,
+		       lz_heap->avail_chunks * CHUNK_UNIT,
+		       lz_heap->avail_chunks_min * CHUNK_UNIT,
+		       lz_heap->avail_contig * CHUNK_UNIT,
+		       lz_heap->avail_contig_min * CHUNK_UNIT,
+		       lz_heap->len * CHUNK_UNIT);
 	}
 	return z_heap->avail_chunks * CHUNK_UNIT;
 }

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -355,21 +355,24 @@ void heap_print_stats(struct z_heap *h)
 #endif
 }
 
-void heap_stats(void)
+uint32_t heap_stats(bool print)
 {
 	extern struct k_heap poolheap__heap_mem_pool;
 	struct k_heap *k_heap = &poolheap__heap_mem_pool;
 	struct sys_heap *s_heap = &k_heap->heap;
 	struct z_heap *z_heap = s_heap->heap;
 
-	printk("Heap stats for %p | Free: %u (min %u) "
-	       "| Contiguous: %u (min %u) | Total: %u\n",
-	       z_heap,
-	       z_heap->avail_chunks * CHUNK_UNIT,
-	       z_heap->avail_chunks_min * CHUNK_UNIT,
-	       z_heap->avail_contig * CHUNK_UNIT,
-	       z_heap->avail_contig_min * CHUNK_UNIT,
-	       z_heap->len * CHUNK_UNIT);
+	if (print) {
+		printk("Heap stats for %p | Free: %u (min %u) "
+		       "| Contiguous: %u (min %u) | Total: %u\n",
+		       z_heap,
+		       z_heap->avail_chunks * CHUNK_UNIT,
+		       z_heap->avail_chunks_min * CHUNK_UNIT,
+		       z_heap->avail_contig * CHUNK_UNIT,
+		       z_heap->avail_contig_min * CHUNK_UNIT,
+		       z_heap->len * CHUNK_UNIT);
+	}
+	return z_heap->avail_chunks * CHUNK_UNIT;
 }
 
 void sys_heap_print_stats(struct sys_heap *heap)

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -357,8 +357,6 @@ void heap_print_stats(struct z_heap *h)
 
 void heap_stats(void)
 {
-	//extern struct k_heap kheap_poolheap__heap_mem_pool;
-	//struct k_heap *k_heap = &kheap_poolheap__heap_mem_pool;
 	extern struct k_heap poolheap__heap_mem_pool;
 	struct k_heap *k_heap = &poolheap__heap_mem_pool;
 	struct sys_heap *s_heap = &k_heap->heap;

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -124,6 +124,11 @@ static void free_chunk(struct z_heap *h, chunkid_t c)
 		c = left_chunk(h, c);
 	}
 
+	if (chunk_size(h, c) > h->avail_contig) {
+		h->top_available = c;
+		h->avail_contig = chunk_size(h, c);
+	}
+
 	free_list_add(h, c);
 }
 
@@ -221,6 +226,33 @@ static chunkid_t alloc_chunk(struct z_heap *h, size_t sz)
 	return 0;
 }
 
+/* O(n) with chunks in the top bucket.*/
+static void update_top_available(struct z_heap *h)
+{
+	CHECK(h->avail_buckets);
+
+	/* Find the bucket for the largest available chunks*/
+	int bi_max = 8 * sizeof(int) - __builtin_clz(h->avail_buckets) - 1;
+	struct z_heap_bucket *b = &h->buckets[bi_max];
+
+	/* Iterate through the bucket to identify the largest chunk */
+	h->avail_contig = 0;
+	chunkid_t first = b->next;
+	do {
+		if (chunk_size(h, b->next) > h->avail_contig) {
+			h->top_available = b->next;
+			h->avail_contig = chunk_size(h, b->next);
+		}
+		b->next = next_free_chunk(h, b->next);
+		CHECK(b->next != 0);
+	} while (b->next != first);
+
+	/* Update minimum free chunk size */
+	if (h->avail_contig < h->avail_contig_min) {
+		h->avail_contig_min = h->avail_contig;
+	}
+}
+
 void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 {
 	struct z_heap *h = heap->heap;
@@ -241,7 +273,14 @@ void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 		free_list_add(h, c + chunk_sz);
 	}
 
+	if (c == h->top_available) {
+		update_top_available(h);
+	}
+
 	set_chunk_used(h, c, true);
+
+	sys_heap_print_stats(heap);
+
 	return chunk_mem(h, c);
 }
 
@@ -293,7 +332,40 @@ void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 	}
 
 	set_chunk_used(h, c, true);
+
+	if (c0 == h->top_available) {
+		update_top_available(h);
+	}
+
+	sys_heap_print_stats(heap);
+
 	return mem;
+}
+
+void heap_print_stats(struct z_heap *h)
+{
+#if 0
+	printk("Heap stats for %p | Free: %u (min %u) "
+	       "| Contiguous: %u (min %u) | Total: %u\n", h,
+	       h->avail_chunks * CHUNK_UNIT,
+	       h->avail_chunks_min * CHUNK_UNIT,
+	       h->avail_contig * CHUNK_UNIT,
+	       h->avail_contig_min * CHUNK_UNIT,
+	       h->len * CHUNK_UNIT);
+#endif
+}
+
+void sys_heap_print_stats(struct sys_heap *heap)
+{
+	heap_print_stats(heap->heap);
+}
+
+void sys_heap_get_stats(struct sys_heap *h, struct sys_heap_stats *stats)
+{
+	stats->avail_chunks = h->heap->avail_chunks;
+	stats->avail_chunks_min = h->heap->avail_chunks_min;
+	stats->avail_contig = h->heap->avail_contig;
+	stats->avail_contig_min = h->heap->avail_contig_min;
 }
 
 void *sys_heap_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
@@ -378,11 +450,18 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 	h->len = buf_sz;
 	h->avail_buckets = 0;
 
+	h->avail_chunks = buf_sz;
+	h->avail_chunks_min = buf_sz;
+
 	int nb_buckets = bucket_idx(h, buf_sz) + 1;
 	size_t chunk0_size = chunksz(sizeof(struct z_heap) +
 				     nb_buckets * sizeof(struct z_heap_bucket));
 
 	__ASSERT(chunk0_size + min_chunk_size(h) < buf_sz, "heap size is too small");
+
+	h->top_available = chunk0_size;
+	h->avail_contig = buf_sz - chunk0_size;
+	h->avail_contig_min = buf_sz - chunk0_size;
 
 	for (int i = 0; i < nb_buckets; i++) {
 		h->buckets[i].next = 0;

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -355,6 +355,25 @@ void heap_print_stats(struct z_heap *h)
 #endif
 }
 
+void heap_stats(void)
+{
+	//extern struct k_heap kheap_poolheap__heap_mem_pool;
+	//struct k_heap *k_heap = &kheap_poolheap__heap_mem_pool;
+	extern struct k_heap poolheap__heap_mem_pool;
+	struct k_heap *k_heap = &poolheap__heap_mem_pool;
+	struct sys_heap *s_heap = &k_heap->heap;
+	struct z_heap *z_heap = s_heap->heap;
+
+	printk("Heap stats for %p | Free: %u (min %u) "
+	       "| Contiguous: %u (min %u) | Total: %u\n",
+	       z_heap,
+	       z_heap->avail_chunks * CHUNK_UNIT,
+	       z_heap->avail_chunks_min * CHUNK_UNIT,
+	       z_heap->avail_contig * CHUNK_UNIT,
+	       z_heap->avail_contig_min * CHUNK_UNIT,
+	       z_heap->len * CHUNK_UNIT);
+}
+
 void sys_heap_print_stats(struct sys_heap *heap)
 {
 	heap_print_stats(heap->heap);

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -357,8 +357,8 @@ void heap_print_stats(struct z_heap *h)
 
 uint32_t heap_stats(bool print)
 {
-	extern struct k_heap poolheap__heap_mem_pool;
-	struct k_heap *k_heap = &poolheap__heap_mem_pool;
+	extern struct k_heap _system_heap;
+	struct k_heap *k_heap = &_system_heap;
 	struct sys_heap *s_heap = &k_heap->heap;
 	struct z_heap *z_heap = s_heap->heap;
 

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -61,6 +61,14 @@ struct z_heap {
 	uint64_t chunk0_hdr_area;  /* matches the largest header */
 	uint32_t len;
 	uint32_t avail_buckets;
+
+	uint32_t avail_chunks;
+	uint32_t avail_chunks_min;
+
+	chunkid_t top_available;
+	uint32_t avail_contig;
+	uint32_t avail_contig_min;
+
 	struct z_heap_bucket buckets[0];
 };
 
@@ -129,6 +137,15 @@ static inline void set_chunk_used(struct z_heap *h, chunkid_t c, bool used)
 {
 	chunk_unit_t *buf = chunk_buf(h);
 	void *cmem = &buf[c];
+
+	if (used) {
+		h->avail_chunks -= chunk_size(h, c);
+		if (h->avail_chunks < h->avail_chunks_min) {
+			h->avail_chunks_min = h->avail_chunks;
+		}
+	} else {
+		h->avail_chunks += chunk_size(h, c);
+	}
 
 	if (big_heap(h)) {
 		if (used) {
@@ -241,5 +258,6 @@ static inline bool size_too_big(struct z_heap *h, size_t bytes)
 
 /* For debugging */
 void heap_dump(struct z_heap *h);
+void heap_print_stats(struct z_heap *h);
 
 #endif /* ZEPHYR_INCLUDE_LIB_OS_HEAP_H_ */

--- a/scripts/coredump/gdbstubs/gdbstub.py
+++ b/scripts/coredump/gdbstubs/gdbstub.py
@@ -139,6 +139,10 @@ class GdbStub(abc.ABC):
         barray = b''
         r = get_mem_region(addr)
         while remaining > 0:
+            if r is None:
+                barray = None
+                break
+
             if addr > r['end']:
                 r = get_mem_region(addr)
 

--- a/subsys/debug/coredump/coredump_backend_logging.c
+++ b/subsys/debug/coredump/coredump_backend_logging.c
@@ -11,6 +11,7 @@
 #include "coredump_internal.h"
 
 #include <logging/log.h>
+#include <logging/log_ctrl.h>
 LOG_MODULE_DECLARE(coredump, CONFIG_KERNEL_LOG_LEVEL);
 
 #define COREDUMP_BEGIN_STR	"BEGIN#"
@@ -34,6 +35,7 @@ char log_buf[LOG_BUF_SZ_RAW];
 
 static void coredump_logging_backend_start(void)
 {
+	LOG_PANIC();
 	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_BEGIN_STR);
 }
 
@@ -47,7 +49,7 @@ static void coredump_logging_backend_error(void)
 	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_ERROR_STR);
 }
 
-static int coredump_logging_backend_buffer_output(uint8_t *buf, size_t buflen)
+static int out(uint8_t *buf, size_t buflen)
 {
 	uint8_t log_ptr = 0;
 	size_t remaining = buflen;
@@ -77,7 +79,7 @@ static int coredump_logging_backend_buffer_output(uint8_t *buf, size_t buflen)
 
 		if ((log_ptr >= LOG_BUF_SZ) || (remaining == 0)) {
 			log_buf[log_ptr] = '\0';
-			LOG_ERR(COREDUMP_PREFIX_STR "%s", log_buf);
+			LOG_ERR(COREDUMP_PREFIX_STR "%s", log_strdup(log_buf));
 			log_ptr = 0;
 		}
 	}
@@ -89,5 +91,5 @@ struct z_coredump_backend_api z_coredump_backend_logging = {
 	.start = coredump_logging_backend_start,
 	.end = coredump_logging_backend_end,
 	.error = coredump_logging_backend_error,
-	.buffer_output = coredump_logging_backend_buffer_output,
+	.buffer_output = out,
 };

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -27,6 +27,11 @@ static struct z_coredump_backend_api
 
 static int error;
 
+#if defined(CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING)
+#include <logging/log.h>
+LOG_MODULE_REGISTER(coredump, CONFIG_KERNEL_LOG_LEVEL);
+#endif
+
 static int dump_header(unsigned int reason)
 {
 	struct z_coredump_hdr_t hdr = {

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -288,7 +288,7 @@ int connect_request_encode(const struct mqtt_client *client,
 	start = buf->cur;
 
 	MQTT_TRC("Encoding Protocol Description. Str:%s Size:%08x.",
-		 mqtt_proto_desc->utf8, mqtt_proto_desc->size);
+		 log_strdup(mqtt_proto_desc->utf8), mqtt_proto_desc->size);
 
 	err_code = pack_utf8_str(mqtt_proto_desc, buf);
 	if (err_code != 0) {
@@ -318,7 +318,7 @@ int connect_request_encode(const struct mqtt_client *client,
 	}
 
 	MQTT_TRC("Encoding Client Id. Str:%s Size:%08x.",
-		 client->client_id.utf8, client->client_id.size);
+		 log_strdup(client->client_id.utf8), client->client_id.size);
 	err_code = pack_utf8_str(&client->client_id, buf);
 	if (err_code != 0) {
 		return err_code;
@@ -332,7 +332,7 @@ int connect_request_encode(const struct mqtt_client *client,
 		connect_flags |= client->will_retain << 5;
 
 		MQTT_TRC("Encoding Will Topic. Str:%s Size:%08x.",
-			 client->will_topic->topic.utf8,
+			 log_strdup(client->will_topic->topic.utf8),
 			 client->will_topic->topic.size);
 		err_code = pack_utf8_str(&client->will_topic->topic, buf);
 		if (err_code != 0) {
@@ -341,7 +341,7 @@ int connect_request_encode(const struct mqtt_client *client,
 
 		if (client->will_message != NULL) {
 			MQTT_TRC("Encoding Will Message. Str:%s Size:%08x.",
-				 client->will_message->utf8,
+				 log_strdup(client->will_message->utf8),
 				 client->will_message->size);
 			err_code = pack_utf8_str(client->will_message, buf);
 			if (err_code != 0) {
@@ -361,7 +361,8 @@ int connect_request_encode(const struct mqtt_client *client,
 		connect_flags |= MQTT_CONNECT_FLAG_USERNAME;
 
 		MQTT_TRC("Encoding Username. Str:%s, Size:%08x.",
-			 client->user_name->utf8, client->user_name->size);
+			 log_strdup(client->user_name->utf8),
+			 client->user_name->size);
 		err_code = pack_utf8_str(client->user_name, buf);
 		if (err_code != 0) {
 			return err_code;
@@ -373,7 +374,8 @@ int connect_request_encode(const struct mqtt_client *client,
 		connect_flags |= MQTT_CONNECT_FLAG_PASSWORD;
 
 		MQTT_TRC("Encoding Password. Str:%s Size:%08x.",
-			 client->password->utf8, client->password->size);
+			 log_strdup(client->password->utf8),
+			 client->password->size);
 		err_code = pack_utf8_str(client->password, buf);
 		if (err_code != 0) {
 			return err_code;

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -94,6 +94,13 @@ config SHELL_ECHO_STATUS
 	help
 	  If enabled shell prints back every input byte.
 
+config SHELL_START_OBSCURED
+	bool "Display asterisk when echoing"
+       default n
+       help
+         If enabled, don't echo actual character, but echo * instead.
+         This is used for login prompts.
+
 config SHELL_VT100_COLORS
 	bool "Enable colors in shell"
 	default y

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -78,7 +78,8 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 		      thread->base.user_options,
 		      thread->base.prio,
 		      thread->base.timeout.dticks);
-	shell_print(shell, "\tstate: %s", k_thread_state_str(thread));
+	shell_print(shell, "\tstate: %s, entry: %p", k_thread_state_str(thread),
+		    thread->entry);
 
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 	ret = 0;

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -51,7 +51,7 @@ static void shell_internal_help_print(const struct shell *shell)
 
 	z_shell_help_cmd_print(shell, &shell->ctx->active_cmd);
 	z_shell_help_subcmd_print(shell, &shell->ctx->active_cmd,
-				  "Subcommands:\n");
+				"Subcommands:\n");
 }
 
 /**
@@ -69,8 +69,8 @@ static int cmd_precheck(const struct shell *shell,
 {
 	if (!arg_cnt_ok) {
 		z_shell_fprintf(shell, SHELL_ERROR,
-				"%s: wrong parameter count\n",
-				shell->ctx->active_cmd.syntax);
+				       "%s: wrong parameter count\n",
+				       shell->ctx->active_cmd.syntax);
 
 		if (IS_ENABLED(CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
 			shell_internal_help_print(shell);
@@ -90,7 +90,7 @@ static inline void state_set(const struct shell *shell, enum shell_state state)
 		cmd_buffer_clear(shell);
 		if (z_flag_print_noinit_get(shell)) {
 			z_shell_fprintf(shell, SHELL_WARNING, "%s",
-					SHELL_MSG_BACKEND_NOT_ACTIVE);
+					       SHELL_MSG_BACKEND_NOT_ACTIVE);
 			z_flag_print_noinit_set(shell, false);
 		}
 		z_shell_print_prompt_and_cmd(shell);
@@ -212,7 +212,7 @@ static void history_handle(const struct shell *shell, bool up)
 
 	/* Start by checking if history is not empty. */
 	history_mode = z_shell_history_get(shell->history, up,
-					   shell->ctx->cmd_buff, &len);
+					 shell->ctx->cmd_buff, &len);
 
 	/* On exiting history mode print backed up command. */
 	if (!history_mode) {
@@ -256,7 +256,7 @@ static bool tab_prepare(const struct shell *shell,
 
 	/* Create argument list. */
 	(void)z_shell_make_argv(argc, *argv, shell->ctx->temp_buff,
-				CONFIG_SHELL_ARGC_MAX);
+			      CONFIG_SHELL_ARGC_MAX);
 
 	if (*argc > CONFIG_SHELL_ARGC_MAX) {
 		return false;
@@ -367,8 +367,8 @@ static void autocomplete(const struct shell *shell,
 	/* no exact match found */
 	if (cmd_len != arg_len) {
 		z_shell_op_completion_insert(shell,
-					     match->syntax + arg_len,
-					     cmd_len - arg_len);
+					   match->syntax + arg_len,
+					   cmd_len - arg_len);
 	}
 
 	/* Next character in the buffer is not 'space'. */
@@ -495,7 +495,7 @@ static void partial_autocomplete(const struct shell *shell,
 
 	if (common) {
 		z_shell_op_completion_insert(shell, &completion[arg_len],
-					     common - arg_len);
+					   common - arg_len);
 	}
 }
 
@@ -516,7 +516,7 @@ static int exec_cmd(const struct shell *shell, size_t argc, const char **argv,
 			return SHELL_CMD_HELP_PRINTED;
 		} else {
 			z_shell_fprintf(shell, SHELL_ERROR,
-					SHELL_MSG_SPECIFY_SUBCOMMAND);
+					       SHELL_MSG_SPECIFY_SUBCOMMAND);
 			return -ENOEXEC;
 		}
 	}
@@ -626,8 +626,8 @@ static int execute(const struct shell *shell)
 
 	if (IS_ENABLED(CONFIG_SHELL_HISTORY)) {
 		z_shell_cmd_trim(shell);
-		history_put(shell, shell->ctx->cmd_buff,
-			    shell->ctx->cmd_buff_len);
+	history_put(shell, shell->ctx->cmd_buff,
+		    shell->ctx->cmd_buff_len);
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
@@ -674,7 +674,7 @@ static int execute(const struct shell *shell)
 			}
 
 			z_shell_fprintf(shell, SHELL_ERROR,
-					SHELL_MSG_SPECIFY_SUBCOMMAND);
+					       SHELL_MSG_SPECIFY_SUBCOMMAND);
 			return -ENOEXEC;
 		}
 
@@ -682,7 +682,7 @@ static int execute(const struct shell *shell)
 			enum shell_wildcard_status status;
 
 			status = z_shell_wildcard_process(shell, entry,
-							  argvp[0]);
+							argvp[0]);
 			/* Wildcard character found but there is no matching
 			 * command.
 			 */
@@ -721,8 +721,8 @@ static int execute(const struct shell *shell)
 				(!z_shell_in_select_mode(shell) ||
 				 shell->ctx->selected_cmd->handler == NULL)) {
 				z_shell_fprintf(shell, SHELL_ERROR,
-						"%s%s\n", argv[0],
-						SHELL_MSG_CMD_NOT_FOUND);
+						       "%s%s\n", argv[0],
+						       SHELL_MSG_CMD_NOT_FOUND);
 			}
 
 			/* last handler found - no need to search commands in
@@ -755,8 +755,8 @@ static int execute(const struct shell *shell)
 		 */
 		(void)z_shell_make_argv(&cmd_lvl,
 					&argv[selected_cmd_get(shell) ? 1 : 0],
-					shell->ctx->cmd_buff,
-					CONFIG_SHELL_ARGC_MAX);
+				      shell->ctx->cmd_buff,
+				      CONFIG_SHELL_ARGC_MAX);
 
 		if (selected_cmd_get(shell)) {
 			/* Apart from what is in the command buffer, there is
@@ -1163,6 +1163,7 @@ static int instance_init(const struct shell *shell, const void *p_config,
 
 	z_flag_tx_rdy_set(shell, true);
 	z_flag_echo_set(shell, IS_ENABLED(CONFIG_SHELL_ECHO_STATUS));
+	flag_obscure_set(shell, true);
 	z_flag_mode_delete_set(shell,
 			     IS_ENABLED(CONFIG_SHELL_BACKSPACE_MODE_DELETE));
 	shell->ctx->vt100_ctx.cons.terminal_wid =
@@ -1248,7 +1249,7 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 
 	if (log_backend && IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 		z_shell_log_backend_enable(shell->log_backend, (void *)shell,
-					   log_level);
+					 log_level);
 	}
 
 	/* Enable shell and print prompt. */
@@ -1265,7 +1266,7 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 		if (err != 0) {
 			k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
 			z_shell_fprintf(shell, SHELL_ERROR,
-					"Shell thread error: %d", err);
+					       "Shell thread error: %d", err);
 			k_mutex_unlock(&shell->ctx->wr_mtx);
 			return;
 		}

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1163,7 +1163,7 @@ static int instance_init(const struct shell *shell, const void *p_config,
 
 	z_flag_tx_rdy_set(shell, true);
 	z_flag_echo_set(shell, IS_ENABLED(CONFIG_SHELL_ECHO_STATUS));
-	flag_obscure_set(shell, true);
+	flag_obscure_set(shell, IS_ENABLED(CONFIG_SHELL_START_OBSCURED));
 	z_flag_mode_delete_set(shell,
 			     IS_ENABLED(CONFIG_SHELL_BACKSPACE_MODE_DELETE));
 	shell->ctx->vt100_ctx.cons.terminal_wid =

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -112,7 +112,7 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 	static const uint8_t tabulator[] = "  ";
 	const uint16_t offset = 2 * strlen(tabulator) + item_name_width + 1;
 
-	if (item_name == NULL) {
+	if ((item_name == NULL) || (item_name[0] == '\0')) {
 		return;
 	}
 

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -101,12 +101,12 @@ static void msg_to_fifo(const struct shell *shell,
 	{
 		flush_expired_messages(shell);
 
-		err = k_msgq_put(shell->log_backend->msgq, &msg, K_NO_WAIT);
+		err = k_msgq_put(shell->log_backend->msgq, &t_msg, K_NO_WAIT);
 		if (err) {
 			/* Unexpected case as we just freed one element and
 			 * there is no other context that puts into the msgq.
 			 */
-			__ASSERT_NO_MSG(0);
+			printk("ERROR %d: NO MESSAGE\n", err);
 		}
 		break;
 	}

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -11,8 +11,8 @@ void z_shell_op_cursor_vert_move(const struct shell *shell, int32_t delta)
 {
 	if (delta != 0) {
 		z_shell_raw_fprintf(shell->fprintf_ctx, "\033[%d%c",
-				    delta > 0 ? delta : -delta,
-				    delta > 0 ? 'A' : 'B');
+				  delta > 0 ? delta : -delta,
+				  delta > 0 ? 'A' : 'B');
 	}
 }
 
@@ -20,8 +20,8 @@ void z_shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta)
 {
 	if (delta != 0) {
 		z_shell_raw_fprintf(shell->fprintf_ctx, "\033[%d%c",
-				    delta > 0 ? delta : -delta,
-				    delta > 0 ? 'C' : 'D');
+				  delta > 0 ? delta : -delta,
+				  delta > 0 ? 'C' : 'D');
 	}
 }
 
@@ -54,7 +54,7 @@ void z_shell_op_cursor_position_synchronize(const struct shell *shell)
 	bool last_line;
 
 	z_shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
-				    shell->ctx->cmd_buff_len);
+				  shell->ctx->cmd_buff_len);
 	last_line = (cons->cur_y == cons->cur_y_end);
 
 	/* In case cursor reaches the bottom line of a terminal, it will
@@ -82,17 +82,17 @@ void z_shell_op_cursor_move(const struct shell *shell, int16_t val)
 	int32_t col_span;
 
 	z_shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
-				    shell->ctx->cmd_buff_len);
+				  shell->ctx->cmd_buff_len);
 
 	/* Calculate the new cursor. */
 	row_span = z_row_span_with_buffer_offsets_get(
 						&shell->ctx->vt100_ctx.cons,
-						shell->ctx->cmd_buff_pos,
-						new_pos);
+						    shell->ctx->cmd_buff_pos,
+						    new_pos);
 	col_span = z_column_span_with_buffer_offsets_get(
-						&shell->ctx->vt100_ctx.cons,
-						shell->ctx->cmd_buff_pos,
-						new_pos);
+						    &shell->ctx->vt100_ctx.cons,
+						    shell->ctx->cmd_buff_pos,
+						    new_pos);
 
 	z_shell_op_cursor_vert_move(shell, -row_span);
 	z_shell_op_cursor_horiz_move(shell, col_span);
@@ -223,8 +223,15 @@ static void reprint_from_cursor(const struct shell *shell, uint16_t diff,
 		z_clear_eos(shell);
 	}
 
-	z_shell_fprintf(shell, SHELL_NORMAL, "%s",
-		      &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
+	if (flag_obscure_get(shell)) {
+		int len = strlen(&shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
+		while (len--) {
+			shell_raw_fprintf(shell->fprintf_ctx, "*");
+		}
+	} else {
+		z_shell_fprintf(shell, SHELL_NORMAL, "%s",
+			      &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
+	}
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
 
 	if (full_line_cmd(shell)) {
@@ -264,6 +271,9 @@ static void char_replace(const struct shell *shell, char data)
 
 	if (!z_flag_echo_get(shell)) {
 		return;
+	}
+	if (flag_obscure_get(shell)) {
+		data = '*';
 	}
 
 	z_shell_raw_fprintf(shell->fprintf_ctx, "%c", data);
@@ -316,8 +326,8 @@ void z_shell_op_delete_from_cursor(const struct shell *shell)
 }
 
 void z_shell_op_completion_insert(const struct shell *shell,
-				  const char *compl,
-				  uint16_t compl_len)
+				const char *compl,
+				uint16_t compl_len)
 {
 	data_insert(shell, compl, compl_len);
 }
@@ -325,8 +335,8 @@ void z_shell_op_completion_insert(const struct shell *shell,
 void z_shell_cmd_line_erase(const struct shell *shell)
 {
 	z_shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
-				    shell->ctx->cmd_buff_pos,
-				    shell->ctx->cmd_buff_len);
+				  shell->ctx->cmd_buff_pos,
+				  shell->ctx->cmd_buff_len);
 	z_shell_op_cursor_horiz_move(shell,
 				   -(shell->ctx->vt100_ctx.cons.cur_x - 1));
 	z_shell_op_cursor_vert_move(shell, shell->ctx->vt100_ctx.cons.cur_y - 1);
@@ -415,7 +425,7 @@ static void vt100_bgcolor_set(const struct shell *shell,
 }
 
 void z_shell_vt100_color_set(const struct shell *shell,
-			     enum shell_vt100_color color)
+			   enum shell_vt100_color color)
 {
 
 	if (shell->ctx->vt100_ctx.col.col == color) {

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -226,7 +226,7 @@ static void reprint_from_cursor(const struct shell *shell, uint16_t diff,
 	if (flag_obscure_get(shell)) {
 		int len = strlen(&shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
 		while (len--) {
-			shell_raw_fprintf(shell->fprintf_ctx, "*");
+			z_shell_raw_fprintf(shell->fprintf_ctx, "*");
 		}
 	} else {
 		z_shell_fprintf(shell, SHELL_NORMAL, "%s",

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -90,12 +90,12 @@ static inline void z_flag_echo_set(const struct shell *shell, bool val)
 	shell->ctx->internal.flags.echo = val ? 1 : 0;
 }
 
-static inline bool flag_obscure_get(const struct shell *shell)
+inline bool flag_obscure_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.obscure == 1;
 }
 
-static inline void flag_obscure_set(const struct shell *shell, bool val)
+inline void flag_obscure_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.obscure = val ? 1 : 0;
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 static inline void z_shell_raw_fprintf(const struct shell_fprintf *const ctx,
-				       const char *fmt, ...)
+				     const char *fmt, ...)
 {
 	va_list args;
 
@@ -88,6 +88,16 @@ static inline bool z_flag_echo_get(const struct shell *shell)
 static inline void z_flag_echo_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.echo = val ? 1 : 0;
+}
+
+static inline bool flag_obscure_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.obscure == 1;
+}
+
+static inline void flag_obscure_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.obscure = val ? 1 : 0;
 }
 
 static inline bool z_flag_processing_get(const struct shell *shell)
@@ -201,8 +211,8 @@ void z_shell_op_char_delete(const struct shell *shell);
 void z_shell_op_delete_from_cursor(const struct shell *shell);
 
 void z_shell_op_completion_insert(const struct shell *shell,
-				  const char *compl,
-				  uint16_t compl_len);
+				const char *compl,
+				uint16_t compl_len);
 
 bool z_shell_cursor_in_empty_line(const struct shell *shell);
 
@@ -244,22 +254,22 @@ void z_shell_print_stream(const void *user_ctx, const char *data, size_t len);
 
 /** @internal @brief Function for setting font color */
 void z_shell_vt100_color_set(const struct shell *shell,
-			     enum shell_vt100_color color);
+			   enum shell_vt100_color color);
 
 static inline void z_shell_vt100_colors_store(const struct shell *shell,
-					      struct shell_vt100_colors *color)
+					    struct shell_vt100_colors *color)
 {
 	memcpy(color, &shell->ctx->vt100_ctx.col, sizeof(*color));
 }
 
 void z_shell_vt100_colors_restore(const struct shell *shell,
-				  const struct shell_vt100_colors *color);
+				const struct shell_vt100_colors *color);
 
 /* This function can be called only within shell thread but not from command
  * handlers.
  */
 void z_shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
-		     const char *fmt, ...);
+			    const char *fmt, ...);
 
 void z_shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
 		      const char *fmt, va_list args);

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -8,6 +8,7 @@
 #include "shell_utils.h"
 #include "shell_wildcard.h"
 
+static uint8_t unfiltered_argument = CONFIG_SHELL_ARGC_MAX;
 extern const struct shell_cmd_entry __shell_root_cmds_start[];
 extern const struct shell_cmd_entry __shell_root_cmds_end[];
 
@@ -61,7 +62,15 @@ void z_shell_multiline_data_calc(struct shell_multiline_cons *cons,
 	cons->cur_x_end = (buff_len + cons->name_len) % cons->terminal_wid + 1;
 }
 
-static char make_argv(char **ppcmd, uint8_t c)
+uint8_t shell_set_unfiltered_argument(uint8_t arg)
+{
+	uint8_t prev = unfiltered_argument;
+
+	unfiltered_argument = arg;
+	return prev;
+}
+
+static char make_argv(char **ppcmd, uint8_t c, size_t argc)
 {
 	char *cmd = *ppcmd;
 	char quote = 0;
@@ -71,6 +80,12 @@ static char make_argv(char **ppcmd, uint8_t c)
 
 		if (c == '\0') {
 			break;
+		}
+
+		/* this argument gets all remaining characters, unmodified */
+		if (argc >= unfiltered_argument) {
+			cmd += 1;
+			continue;
 		}
 
 		if (!quote) {
@@ -192,7 +207,7 @@ char z_shell_make_argv(size_t *argc, const char **argv, char *cmd,
 		if (*argc == max_argc) {
 			break;
 		}
-		quote = make_argv(&cmd, c);
+		quote = make_argv(&cmd, c, (*argc) - 1);
 	} while (true);
 
 	return quote;


### PR DESCRIPTION
Note to reviewers: the relevant commits are:
- rename shell_raw_fprintf to z_shell_raw_fprintf to match Zephyr change `9cc3a43`
- fix global heap symbol name (changed in 1.5.0) `b3e0307`

The other commits are for another branch, also not yet merged (feature-debug-improvements).